### PR TITLE
Preventing stderr.on("end") from invoking the callback when no error has occurred

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ var copy = GLOBAL.copy = exports.copy = function(text, cb) {
 			.on("end", function() {
 				if(err.length === 0) { return; }
 				var error = err.join("");
-				
+
 				if(cb) { cb(error); }
 				else { console.log(error); }
 			})


### PR DESCRIPTION
The `stderr.on("end")` handler was set up to join the `err` array and use the resulting string as the first argument to the optional callback, regardless of whether or not `err` actually had any entries. This was causing the callback to be invoked twice: once for the actual success, and once for the false positive error message.

This change makes sure that there has been at least one `data` event on `stderr` before invoking the callback, removing any false positives.
