### PR TITLE
Resolve stack overflow issue in copy with callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ var noop = function() {};
 exports.copy = function(text, cb) {
 	var child = spawn(config.copy.command, config.copy.args);
 
-	cb = cb ? function() { cb.apply(this, arguments); cb = noop; } : noop;
+	cb = cb || noop;
 
 	var err = [];
 


### PR DESCRIPTION
Calling `copy` with a callback causes stack overflow due to recursion from wrapping the passed in callback. Rather than wrapping the callback, use the given callback or `noop`.
