### PR TITLE
Use sync-exec instead of execSync as exec fallback

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,8 +7,8 @@ var execSync = (function() {
 		return function(cmd) { return child_process.execSync(cmd); };
 	} else {
 		try { // Try using fallback package if available
-			var execSync = require("execSync");
-			return function(cmd) { return execSync.exec(cmd).stdout; };
+			var execSync = require("sync-exec");
+			return function(cmd) { return execSync(cmd).stdout; };
 		} catch(e) {}
 	}
 

--- a/package.json
+++ b/package.json
@@ -16,5 +16,5 @@
 , "dependencies":
   { "iconv-lite": "^0.4.8" }
 , "optionalDependencies":
-  { "execSync": "~1.0.0" }
+  { "sync-exec": "~0.6.x" }
 }


### PR DESCRIPTION
Attempting "npm install copy-paste" currently raises the error:

```bash
[execsync v1.0.2] Attempting to compile native extensions.
[execSync v1.0.2]
    Native code compile failed!!
```
This error arises with the dependency execSync and is addressed by
the author of execSync [1] who recommends replacing execSync by
sync-exec [2].

Here we replace execSync with sync-exec, and npm install will run
with no errors.

This fixes issue [#33](github.com/xavi-/node-copy-paste/issues/33).

[1] [mgutz/execSync#38](https://github.com/mgutz/execSync/issues/38)
[2] https://www.npmjs.com/package/sync-exec