### PR TITLE
[Windows] Fix decode function for unicode chars

### DIFF
--- a/platform/fallbacks/paste.vbs
+++ b/platform/fallbacks/paste.vbs
@@ -1,6 +1,52 @@
+Function Base64Encode(sText)
+    Dim oXML, oNode
+
+    Set oXML = CreateObject("Msxml2.DOMDocument.3.0")
+    Set oNode = oXML.CreateElement("base64")
+    oNode.dataType = "bin.base64"
+    oNode.nodeTypedValue =Stream_StringToBinary(sText)
+    Base64Encode = oNode.text
+    Set oNode = Nothing
+    Set oXML = Nothing
+End Function
+
+'Stream_StringToBinary Function
+'2003 Antonin Foller, http://www.motobit.com
+'Text - string parameter To convert To binary data
+Function Stream_StringToBinary(Text)
+  Const adTypeText = 2
+  Const adTypeBinary = 1
+
+  'Create Stream object
+  Dim BinaryStream 'As New Stream
+  Set BinaryStream = CreateObject("ADODB.Stream")
+
+  'Specify stream type - we want To save text/string data.
+  BinaryStream.Type = adTypeText
+
+  'Specify charset For the source text (unicode) data.
+  BinaryStream.CharSet = "utf-8"
+
+  'Open the stream And write text/string data To the object
+  BinaryStream.Open
+  BinaryStream.WriteText Text
+
+  'Change stream type To binary
+  BinaryStream.Position = 0
+  BinaryStream.Type = adTypeBinary
+
+  'Ignore first two bytes - sign of
+  BinaryStream.Position = 0
+
+  'Open the stream And get binary data from the object
+  Stream_StringToBinary = BinaryStream.Read
+
+  Set BinaryStream = Nothing
+End Function
+
 Dim objHTML
 
 Set objHTML = CreateObject("htmlfile")
 text = objHTML.ParentWindow.ClipboardData.GetData("Text")
 
-Wscript.Echo text
+Wscript.Echo Base64Encode(text)

--- a/platform/win32.js
+++ b/platform/win32.js
@@ -13,6 +13,10 @@ exports.encode = function(str) { return iconv.encode(str, "utf16le"); };
 exports.decode = function(chunks) {
 	if(!Array.isArray(chunks)) { chunks = [ chunks ]; }
 
-	var str = iconv.decode(Buffer.concat(chunks), "cp437");
-	return str.substr(0, str.length - 2); // Chops off extra "\r\n"
+	var b64 = iconv.decode(Buffer.concat(chunks), "cp437");
+	b64 = b64.substr(0, b64.length - 2); // Chops off extra "\r\n"
+    
+    // remove bom and decode
+    var result = new Buffer(b64, "base64").slice(3).toString("utf-8");
+    return result;
 };


### PR DESCRIPTION
As stated in #40 copy and paste of some unicode chars does not work. For the paste part the problem seemed to be the encoding of the child_process's stdout channel. I changed the code so that the vb script encodes the content of the clipboard in base64. On the javascipt side this is then be decoded.