### PR TITLE
[Windows] on copy: using UTF-8 and unicode code page

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ exports.copy = function(text, callback) {
 			.on("data", function(chunk) { err.push(chunk); })
 			.on("end", function() {
 				if(err.length === 0) { return; }
-				done(new Error(config.decode(err)));
+				done(new Error(config.decode(err, true)));
 			})
 	;
 
@@ -90,7 +90,7 @@ exports.paste = function(callback) {
 			.on("end", function() {
 				if(err.length === 0) { return; }
 
-				done(new Error(config.decode(err)));
+				done(new Error(config.decode(err, true)));
 			})
 		;
 	} else {

--- a/platform/fallbacks/copy.bat
+++ b/platform/fallbacks/copy.bat
@@ -1,0 +1,8 @@
+::Setting this code page is more likely to make isTextUnicode return true, making clip.exe do what we want.
+chcp 65001 & ::UTF-8
+
+clip & ::Reads stdin
+
+::This is the default code page for the US locale. It might not be the user's original code page. This *probably* doesn't matter.
+::Restoring this code page makes cmd.exe behave nicely! Without this it freezes when running the tests.
+chcp 437 & ::US ASCII (restore)

--- a/platform/win32.js
+++ b/platform/win32.js
@@ -1,22 +1,29 @@
 var iconv = require("iconv-lite");
 var path = require("path");
 
-var vbsPath = path.join(__dirname, ".\\fallbacks\\paste.vbs");
+var copyHelperPath = path.join(__dirname, ".\\fallbacks\\copy.bat");
+var pasteHelperPath = path.join(__dirname, ".\\fallbacks\\paste.vbs");
 
-var paste = { command: "cscript", args: [ "/Nologo", vbsPath ] };
-paste.full_command = [ paste.command, paste.args[0], '"'+vbsPath+'"' ].join(" ");
+var paste = { command: "cscript", args: [ "/Nologo", pasteHelperPath ] };
+paste.full_command = [ paste.command, paste.args[0], '"'+pasteHelperPath+'"' ].join(" ");
 
-exports.copy = { command: "clip", args: [] };
+exports.copy = { command: "cmd", args: [ "/U", "/C", copyHelperPath ] };
 exports.paste = paste;
 
-exports.encode = function(str) { return iconv.encode(str, "utf16le"); };
-exports.decode = function(chunks) {
-	if(!Array.isArray(chunks)) { chunks = [ chunks ]; }
+// explicitly do not add BOM otherwise clip.exe might include the BOM in the text that is copied to the clipboard!
+exports.encode = function(str) { return iconv.encode(str, "utf-8", {addBOM: false}); };
+exports.decode = function(chunks, isError) {
+    if (isError) {
+        // no base64 decoding error messages!
+        return chunks;
+    } else {
+        if(!Array.isArray(chunks)) { chunks = [ chunks ]; }
 
-	var b64 = iconv.decode(Buffer.concat(chunks), "cp437");
-	b64 = b64.substr(0, b64.length - 2); // Chops off extra "\r\n"
-    
-    // remove bom and decode
-    var result = new Buffer(b64, "base64").slice(3).toString("utf-8");
-    return result;
+        var b64 = iconv.decode(Buffer.concat(chunks), "cp437");
+        b64 = b64.substr(0, b64.length - 2); // Chops off extra "\r\n"
+
+        // remove bom and decode
+        var result = new Buffer(b64, "base64").slice(3).toString("utf8");
+        return result;
+    }
 };

--- a/test/copypaste.js
+++ b/test/copypaste.js
@@ -36,4 +36,14 @@ describe('copy and paste', function () {
     
     copy_and_paste("±", done);
   });
+  
+  it('should work correctly for "❤"', function (done) {
+    
+    copy_and_paste("❤", done);
+  });
+  
+  it('should work correctly for "돋움"', function (done) {
+    
+    copy_and_paste("돋움", done);
+  });
 });


### PR DESCRIPTION
Resolves #40 

##### The problem
* We have been encoding data to copy as UTF-16LE, which should be fine!
* Unfortunately Windows (specifically clip.exe) appears to use the dreaded [`isTextUnicode`](https://en.wikipedia.org/wiki/Bush_hid_the_facts) to decide character encoding.
* This means that sometimes extended chars copy correctly, other times not. (Demonstrated in test cases in notatestuser/node-copy-paste@f8b93be on Windows)

##### What this PR changes
* Use a .bat to spawn clip.exe
* Change the active code page to 65001
* Pipe UTF-8 to clip.exe
* Change the code page back once done

This way `isTextUnicode` is more likely to give us its blessing.

##### Things I tried
* Adding a BOM (works, but BOM is also copied to clipboard as extra data)
* Using a file encoded as UTF-16LE (results in the same BOM issue - BOM-less files must be UTF-8, which yields mixed results)
* VB script with base64 for copying (crap, slow)