### PR TITLE
Windows: wrap __dirname path in quotes to account for spaces

### DIFF
--- a/platform/win32.js
+++ b/platform/win32.js
@@ -1,7 +1,7 @@
 var iconv = require("iconv-lite");
 var path = require("path");
 
-var vbsPath = path.join(__dirname, ".\\fallbacks\\paste.vbs");
+var vbsPath = path.join("\"" + __dirname, ".\\fallbacks\\paste.vbs" + "\"");
 
 var paste = { command: "cscript", args: [ "/Nologo", vbsPath ] };
 paste.full_command = [ paste.command, paste.args[0], '"'+vbsPath+'"' ].join(" ");
@@ -15,7 +15,7 @@ exports.decode = function(chunks) {
 
 	var b64 = iconv.decode(Buffer.concat(chunks), "cp437");
 	b64 = b64.substr(0, b64.length - 2); // Chops off extra "\r\n"
-    
+
     // remove bom and decode
     var result = new Buffer(b64, "base64").slice(3).toString("utf-8");
     return result;


### PR DESCRIPTION
In Windows if `__dirname` points to a folder which is inside any folder with a space in it's name then when trying to execute the 'paste' fallback it would fail and throw the following error:

`Error: Command failed: cscript /Nologo C:\Users\User Directory\node-copy-paste\platform\fallbacks\paste.vbs`
_Notice here that `User Directory` has a space in it's name._ 

When the whole `node-copy-paste` folder is in a path with no spaces (for example `C:\`) running 'paste' doesn't throw any errors. Wrapping the whole path in quotes makes the command work correctly.

I'm using Node 6.2.2 on Windows 10 and this fix works, I'm not sure if this problem was also present in other versions of Windows.