### PR TITLE
Check for pid before attempting to copy

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,16 +58,18 @@ exports.copy = function(text, callback) {
 			})
 	;
 
-	if(text.pipe) { text.pipe(child.stdin); }
-	else {
-		var output, type = Object.prototype.toString.call(text);
+	if(child.pid) {
+		if(text.pipe) { text.pipe(child.stdin); }
+		else {
+			var output, type = Object.prototype.toString.call(text);
 
-		if(type === "[object String]") { output = text; }
-		else if(type === "[object Object]") { output = util.inspect(text, { depth: null }); }
-		else if(type === "[object Array]") { output = util.inspect(text, { depth: null }); }
-		else { output = text.toString(); }
+			if(type === "[object String]") { output = text; }
+			else if(type === "[object Object]") { output = util.inspect(text, { depth: null }); }
+			else if(type === "[object Array]") { output = util.inspect(text, { depth: null }); }
+			else { output = text.toString(); }
 
-		child.stdin.end(config.encode(output));
+			child.stdin.end(config.encode(output));
+		}
 	}
 
 	return text;


### PR DESCRIPTION
On Linux, when `xclip` isn't installed, `copy` will fail and raise a `SIGPIPE` that may end the parent process. This change ensures that nothing is streamed to the failed command and that the error is properly passed to the callback (if any).

For reference, see this issue: zeit/serve#111