### PR TITLE
:shower: Remove exec-sync dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,19 +1,7 @@
 var child_process = require("child_process");
 var spawn = child_process.spawn;
+var execSync = child_process.execSync;
 var util = require("util");
-
-var execSync = (function() {
-	if(child_process.execSync) { // Use native execSync if avaiable
-		return function(cmd) { return child_process.execSync(cmd); };
-	} else {
-		try { // Try using fallback package if available
-			var execSync = require("sync-exec");
-			return function(cmd) { return execSync(cmd).stdout; };
-		} catch(e) {}
-	}
-
-	return null;
-})();
 
 var config;
 

--- a/package.json
+++ b/package.json
@@ -15,8 +15,6 @@
   }
 , "dependencies":
   { "iconv-lite": "^0.4.8" }
-, "optionalDependencies":
-  { "sync-exec": "~0.6.x" }
 , "devDependencies":
   { "mocha": "*", "should": ">=8.2.1" }
 , "scripts":


### PR DESCRIPTION
As pointed out in https://github.com/xavi-/node-copy-paste/issues/61, the lib exec-sync triggers security alerts (mine was shown by snyk). 

This PR aims at removing the dependency as it is safe now that the native version of execSync has been out for a long while.