### PR TITLE
Fix paste on WSL

### DIFF
--- a/platform/linux.js
+++ b/platform/linux.js
@@ -5,7 +5,7 @@ exports.copy =
 
 exports.paste =
 	process.env.WSL_DISTRO_NAME ?
-	{ command: "powershell.exe", args: ["-command", "Get-Clipboard"] } :
+	{ command: "powershell.exe", args: ['-noprofile', '-command', 'Get-Clipboard'] } :
 	{ command: "xclip", args: [ "-selection", "clipboard", "-o" ] };
   
 exports.paste.full_command = [ exports.paste.command ].concat(exports.paste.args).join(" ");
@@ -13,5 +13,12 @@ exports.encode = function(str) { return Buffer.from(str, "utf8"); };
 exports.decode = function(chunks) {
 	if(!Array.isArray(chunks)) { chunks = [ chunks ]; }
 
-	return Buffer.concat(chunks).toString("utf8");
+	var output = Buffer.concat(chunks).toString("utf8");
+
+	// Check if running under WSL and strip the last two characters added by powershell.exe
+	if (process.env.WSL_DISTRO_NAME) {
+		output = output.slice(0, -2);
+	}
+
+	return output;
 };

--- a/platform/linux.js
+++ b/platform/linux.js
@@ -3,7 +3,11 @@ exports.copy =
 	{ command: "clip.exe", args: [] } :
   	{ command: "xclip", args: [ "-selection", "clipboard" ] };
 
-exports.paste = { command: "xclip", args: [ "-selection", "clipboard", "-o" ] };
+exports.paste =
+	process.env.WSL_DISTRO_NAME ?
+	{ command: "powershell.exe", args: ["-command", "Get-Clipboard"] } :
+	{ command: "xclip", args: [ "-selection", "clipboard", "-o" ] };
+  
 exports.paste.full_command = [ exports.paste.command ].concat(exports.paste.args).join(" ");
 exports.encode = function(str) { return Buffer.from(str, "utf8"); };
 exports.decode = function(chunks) {


### PR DESCRIPTION
This fixes 'paste' on WSL. Before it would print something that was not a string - a buffer I guess.  

It also passes all tests on WSL. It also passes all test on linux. 

Before this edit. No tests passed on WSL.