### PR TITLE
fix: support Chinese Chars in Macos

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,9 +74,11 @@ exports.copy = function(text, callback) {
 
 var pasteCommand = [ config.paste.command ].concat(config.paste.args).join(" ");
 exports.paste = function(callback) {
-	if(execSync && !callback) { return config.decode(execSync(pasteCommand)); }
-	else if(callback) {
-		var child = spawn(config.paste.command, config.paste.args);
+	const opts = { env: Object.assign({}, process.env, config.paste.env) };
+	if(execSync && !callback) { 
+		return config.decode(execSync(pasteCommand, { env : opts.env })); 
+	} else if(callback) {
+		var child = spawn(config.paste.command, config.paste.args, opts);
 
 		var done = callback && function() { callback.apply(this, arguments); done = noop; };
 

--- a/test/copypaste.js
+++ b/test/copypaste.js
@@ -36,4 +36,10 @@ describe('copy and paste', function () {
     
     copy_and_paste("±", done);
   });
+
+  it('should work correctly with Chinese chars', function (done) {
+    
+    copy_and_paste("你好，我是中文", done);
+  });
+  
 });


### PR DESCRIPTION
paste command did not have environment parameter LANG, so it does not support Chinese Chars.

Also, I add another test case