### PR TITLE
Add support for Wayland (requires wl-clipboard)

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,11 @@ switch(process.platform) {
 		config = require("./platform/win32");
 		break;
 	case "linux":
-		config = require("./platform/linux");
+		if (process.env.WAYLAND_DISPLAY) {
+			config = require("./platform/linux-wayland");
+		} else {
+			config = require("./platform/linux");
+		}
 		break;
 	case "freebsd":
 		config = require("./platform/linux");

--- a/platform/linux-wayland.js
+++ b/platform/linux-wayland.js
@@ -1,0 +1,14 @@
+exports.copy =
+ 	process.env.WSL_DISTRO_NAME ?
+	{ command: "clip.exe", args: [] } :
+  	{ command: "wl-copy", args: [] };
+
+
+exports.paste = { command: "wl-paste", args: [] };
+exports.paste.full_command = [ exports.paste.command ].concat(exports.paste.args).join(" ");
+exports.encode = function(str) { return Buffer.from(str, "utf8"); };
+exports.decode = function(chunks) {
+	if(!Array.isArray(chunks)) { chunks = [ chunks ]; }
+
+	return Buffer.concat(chunks).toString("utf8");
+};


### PR DESCRIPTION
Checks the WAYLAND_DISPLAY env variable to determine if the OS is running Wayland (instead of X11).

Then it uses [wl-clipboard](https://github.com/bugaevc/wl-clipboard) for copy/paste.

(There might be better solutions out there, but this is working for me on Fedora41)